### PR TITLE
[86azm6ruw] Move ubuntu_ami to variable.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,16 +9,12 @@ terraform {
   required_version = ">= 1.2.0"
 }
 
-locals {
-  ubuntu_ami = "ami-0c7217cdde317cfec"
-}
-
 provider "aws" {
   region  = "us-east-1"
 }
 
 resource "aws_instance" "ec2_ubuntu_instance" {
-  ami           = local.ubuntu_ami
+  ami           = var.ubuntu_ami
   instance_type = "t2.micro"
 
   tags = {

--- a/variable.tf
+++ b/variable.tf
@@ -1,0 +1,5 @@
+variable "ubuntu_ami" {
+  type        = string
+  default     = "ami-0c7217cdde317cfec"
+  description = "Ubuntu AMI to install on EC2 instance"
+}


### PR DESCRIPTION
#### ClickUp ticket 86azm6ruw
### Changes
Moved the `ubuntu_ami` to a new file called `variable.tf`. The `variable.tf` file will host the majority, if not all of our Terraform variables.

I will also create a `terraform.tfvars` file in a later PR that I won't check in that will declare the value of future sensitive variables (I'm not keen on plastering my IP address and other variables on my public GitHub).