### PR TITLE
[86azp41ww] Add count meta argument to pem file creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,7 @@ resource "aws_key_pair" "ssh_key" {
 }
 
 resource "local_sensitive_file" "ssh_pem" {
+  count                = var.gen_pem_file ? 1 : 0
   filename             = pathexpand("~/.ssh/ssh.pem")
   file_permission      = "600"
   directory_permission = "700"

--- a/variable.tf
+++ b/variable.tf
@@ -6,5 +6,12 @@ variable "ubuntu_ami" {
 
 variable "key_name" {
   type        = string
+  default     = "default"
   description = "Name of the EC2 key pair"
+}
+
+variable "gen_pem_file" {
+  type        = bool
+  default     = false
+  description = "Generate a new PEM file for the EC2 key pair"
 }


### PR DESCRIPTION
### Changes
Added the `count` meta argument and variable `gen_pem_file` to the `local_sensitive_file` resource so the file does not generate by default. I have the value overridden to `true` in my local `terraform.tfvars` file.