### PR TITLE
[86azq044r] Add terraform-docs GitHub Actions workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,21 @@
+name: Generate terraform docs
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: main
+
+    - name: Render terraform docs inside the README.md and push changes back to PR branch
+      uses: terraform-docs/gh-actions@v1.0.0
+      with:
+        working-dir: .
+        output-file: README.md
+        output-method: inject
+        git-push: "true"

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -15,7 +15,7 @@ jobs:
   terraform:
     if: github.repository == 'kngatineau/terraform-aws'
     name: "Terraform Apply"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -13,7 +13,7 @@ jobs:
   terraform:
     if: github.repository == 'kngatineau/terraform-aws'
     name: "Terraform Plan"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
#### ClickUp ticket 86azq044r
### Changes

1. Added `terraform-docs` GitHub Actions workflow to this project to automate the `terraform-docs` generation, see `.github/workflows/documentation.yml`
2. Snuck in updating the Ubuntu version of which the workflow runs on for the `.github/workflows/terraform*` workflows to `ubuntu-latest`.