### PR TITLE
[86azq09fe] Update config directory in terraform-apply workflow

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -9,7 +9,7 @@ env:
   TF_CLOUD_ORGANIZATION: "kngatineau"
   TF_API_TOKEN: "${{ secrets.TF_API_TOKEN }}"
   TF_WORKSPACE: "terraform-aws"
-  CONFIG_DIRECTORY: "./"
+  CONFIG_DIRECTORY: "./tf/"
 
 jobs:
   terraform:


### PR DESCRIPTION
#### ClickUp ticket 86azq09fe
### Changes

Silly me updated the configuration directory for the workflow to automate the `terraform plan`, however, I missed the update for `terraform apply`. My imaginary friends obviously need to do better at their code reviews. 😤 

The `terraform-docs` workflow failed because I have branch protection enabled on `main`. Which makes me dislike this setup even more because I had to remove that protection to make it work. I will be looking into this config tomorrow to see how noisy it is in "PR mode".