### PR TITLE
[86b04wguq] Create s3 bucket to hold Lambda functions

### DIFF
--- a/tf/README.md
+++ b/tf/README.md
@@ -25,6 +25,7 @@
 | [aws_iam_group.admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group) | resource |
 | [aws_iam_group_policy.admin_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy) | resource |
 | [aws_instance.ec2_ubuntu_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [aws_s3_bucket.lambda_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_security_group.main_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.allow_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_subnet.main_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
@@ -36,6 +37,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_ips"></a> [allowed\_ips](#input\_allowed\_ips) | List of allowed IPs to access the EC2 instance | `list(string)` | n/a | yes |
+| <a name="input_lambda_bucket_name"></a> [lambda\_bucket\_name](#input\_lambda\_bucket\_name) | Name of the S3 bucket that holds Lambda functions | `string` | `"katies-lambda-bucket"` | no |
 | <a name="input_ubuntu_ami"></a> [ubuntu\_ami](#input\_ubuntu\_ami) | Ubuntu AMI to install on EC2 instance | `string` | `"ami-0c7217cdde317cfec"` | no |
 
 ## Outputs

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -21,6 +21,15 @@ resource "aws_instance" "ec2_ubuntu_instance" {
     Name = "katies_free_tier_instance"
   }
 } 
+
+resource "aws_s3_bucket" "lambda_bucket" {
+  bucket = var.lambda_bucket_name
+
+  tags = {
+    Name = "katies_lambda_bucket"
+  }
+}
+
 # just because you *can* generate SSH keys in Terraform doesn't mean you should. 
 # this commented code technically worked but having the key in the state file isn't ideal.
 #

--- a/tf/variable.tf
+++ b/tf/variable.tf
@@ -4,6 +4,12 @@ variable "ubuntu_ami" {
   description = "Ubuntu AMI to install on EC2 instance"
 }
 
+variable "lambda_bucket_name" {
+  type        = string
+  default     = "katies-lambda-bucket"
+  description = "Name of the S3 bucket that holds Lambda functions"
+}
+
 # variable "key_name" {
 #   type        = string
 #   default     = "default"


### PR DESCRIPTION
#### ClickUp ticket #86b04wguq
### Changes

Since AWS Lambda offers 1 million free requests and 3.2 million seconds of free compute time per month, I am going to create Lambda functions to monitor the usage of the root account of my AWS account. 

It's not ideal to use the root account, so I will be creating an IAM user for myself before to ensure the root account is only used for absolute necessary processes. The Lambda function will trigger an SNS notification to my email every time it is used. 