### PR TITLE
[86b0df6k4] GitHub Actions: update TF cloud directories

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -9,7 +9,7 @@ env:
   TF_CLOUD_ORGANIZATION: "kngatineau"
   TF_API_TOKEN: "${{ secrets.TF_API_TOKEN }}"
   TF_WORKSPACE: "terraform-aws"
-  CONFIG_DIRECTORY: "./tf/"
+  CONFIG_DIRECTORY: .
 
 jobs:
   terraform:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -7,7 +7,7 @@ env:
   TF_CLOUD_ORGANIZATION: "kngatineau"
   TF_API_TOKEN: "${{ secrets.TF_API_TOKEN }}"
   TF_WORKSPACE: "terraform-aws"
-  CONFIG_DIRECTORY: "./tf/"
+  CONFIG_DIRECTORY: .
 
 jobs:
   terraform:


### PR DESCRIPTION
### Changes

In order to support an upcoming change in file structure, I needed to explicitly set the `WORKING_DIRECTORY` in Terraform Cloud to the `tf/` directory. 

Now we refer to the `tf` directory as `.` in our yaml files instead of `tf` because the working directory will be set to `terraform-aws/tf` prior to running the actions.